### PR TITLE
Fix api breakage and improve connman api translation method

### DIFF
--- a/apps/cmstapp/code/control_box/controlbox.cpp
+++ b/apps/cmstapp/code/control_box/controlbox.cpp
@@ -1813,7 +1813,6 @@ bool ControlBox::getArray(QList<arrayElement>& r_list, const QDBusMessage& r_msg
 			if (itr.value().canConvert(QMetaType::QStringList)) {
 				QStringList sl = itr.value().toStringList();
 				for (int i = 0; i < sl.size(); ++i) {
-					// TODO remove me // sl.replace(i, cmtr(sl.at(i)) );
                                         sl.replace(i, sl.at(i) );
 				}	// stringlist loop
 				ael.objmap.insert(itr.key(), QVariant::fromValue(sl) );
@@ -1856,12 +1855,10 @@ bool ControlBox::getMap(QMap<QString,QVariant>& r_map, const QDBusMessage& r_msg
     qdb_arg >> key >> value;
     
 		// store translated text (if some exists)    
-		// TODO remove me // if (value.canConvert(QMetaType::QString)) value = QVariant::fromValue(cmtr(value.toString()) );
-                if (value.canConvert(QMetaType::QString)) value = QVariant::fromValue(value.toString() );
+    if (value.canConvert(QMetaType::QString)) value = QVariant::fromValue(value.toString() );
 		if (value.canConvert(QMetaType::QStringList)) {
 			QStringList sl = value.toStringList();
 			for (int i = 0; i < sl.size(); ++i) {
-				// TODO remove me // sl.replace(i, cmtr(sl.at(i)) );
                                 sl.replace(i, sl.at(i) );
 			}	// stringlist loop
 			value = QVariant::fromValue(sl);
@@ -1907,12 +1904,10 @@ bool ControlBox::extractMapData(QMap<QString,QVariant>& r_map, const QVariant& r
       qdba >> key >> value;
       
 			// store translated text (if some exists)    
-			// TODO remove me // if (value.canConvert(QMetaType::QString)) value = QVariant::fromValue(cmtr(value.toString()) );
-                        if (value.canConvert(QMetaType::QString)) value = QVariant::fromValue(value.toString());
+			if (value.canConvert(QMetaType::QString)) value = QVariant::fromValue(value.toString());
 			if (value.canConvert(QMetaType::QStringList)) {
 				QStringList sl = value.toStringList();
 				for (int i = 0; i < sl.size(); ++i) {
-					// TODO remove me // sl.replace(i, cmtr(sl.at(i)) );
                                         sl.replace(i, sl.at(i));
 				}	// stringlist loop
 				value = QVariant::fromValue(sl);

--- a/apps/cmstapp/code/control_box/controlbox.cpp
+++ b/apps/cmstapp/code/control_box/controlbox.cpp
@@ -1988,33 +1988,23 @@ void ControlBox::clearCounters()
 // Function to allow translations of strings returned by Connman. 
 QString ControlBox::cmtr(const QString& instr)
 {
-	if (instr.contains("idle", Qt::CaseInsensitive) ) return tr("idle", "connman state string");
-	else if (instr.contains("association", Qt::CaseInsensitive) ) return tr("association", "connman state string");
-		else if (instr.contains("configuration", Qt::CaseInsensitive) ) return tr("configuration", "connman state string");
-			else if (instr.contains("ready", Qt::CaseInsensitive) ) return tr("ready", "connman state string");
-				else if (instr.contains("online", Qt::CaseInsensitive) ) return tr("online", "connman state string");
-					else if (instr.contains("disconnect", Qt::CaseInsensitive) ) return tr("disconnect", "connman state string");
-						else if (instr.contains("failure", Qt::CaseInsensitive) ) return tr("failure", "connman state string");	
-								
-							else if (instr.contains("system", Qt::CaseInsensitive) ) return tr("system", "connman type string");
-								else if (instr.contains("ethernet", Qt::CaseInsensitive) ) return tr("ethernet", "connman type string");
-									else if (instr.contains("wifi", Qt::CaseInsensitive) ) return tr("wifi", "connman type string");
-										else if (instr.contains("bluetooth", Qt::CaseInsensitive) ) return tr("bluetooth", "connman type string");
-											else if (instr.contains("cellular", Qt::CaseInsensitive) ) return tr("cellular", "connman type string");
-												else if (instr.contains("gps", Qt::CaseInsensitive) ) return tr("gps", "connman type string");
-													else if (instr.contains("vpn", Qt::CaseInsensitive) ) return tr("vpn", "connman type string");
-														else if (instr.contains("gadget", Qt::CaseInsensitive) ) return tr("gadget", "connman type string");
-															else if (instr.contains("p2p", Qt::CaseInsensitive) ) return tr("p2p", "connman type string");		
-																else if (instr.contains("wired", Qt::CaseInsensitive) ) return tr("wired", "connman type string");																												
-														
-																	else if (instr.contains("direct", Qt::CaseInsensitive) ) return tr("direct", "connman proxy string");
-																		else if (instr.contains("manual", Qt::CaseInsensitive) ) return tr("manual", "connman proxy string");
-																			else if (instr.contains("auto", Qt::CaseInsensitive) ) return tr("auto", "connman proxy string");
-																				else if (instr.contains("psk", Qt::CaseInsensitive) ) return tr("psk", "connman security string");
-																					else if (instr.contains("ieee8021x", Qt::CaseInsensitive) ) return tr("ieee8021x", "connman security string");
-																						else if (instr.contains("none", Qt::CaseInsensitive) ) return tr("none", "connman security string");
-																							else if (instr.contains("wep", Qt::CaseInsensitive) ) return tr("wep", "connman security string");												
-	return instr; 
+    QStringList connman_state_strings;
+    connman_state_strings << "idle" << "association" << "configuration" << "ready" << "online" << "disconnect" << "failure";
+    QStringList connman_type_strings;
+    connman_type_strings << "system" << "ethernet" << "wifi" << "bluetooth" << "cellular" << "gps" << "vpn" << "gadget" << "p2p" << "wired";
+    QStringList connman_proxy_strings;
+    connman_proxy_strings << "direct" << "manual" << "auto";
+    QStringList connman_security_strings;
+    connman_security_strings << "psk" << "ieee8021x" << "none" << "wep";
+    
+    // use qPrintable because tr expects a standard string input
+    // perhaps improve this by using a class for the connman api
+    if (connman_state_strings.contains(instr)) return tr(qPrintable(instr), "connman state string");
+    else if (connman_type_strings.contains(instr)) return tr(qPrintable(instr), "connman type string");
+    else if (connman_proxy_strings.contains(instr)) return tr(qPrintable(instr), "connman proxy string");
+    else if (connman_security_strings.contains(instr)) return tr(qPrintable(instr), "connman security string");
+        
+    return instr;
 }
 
 // Slot to connect to the notification client. Called from QTimers to give time for the notification server

--- a/apps/cmstapp/code/control_box/controlbox.cpp
+++ b/apps/cmstapp/code/control_box/controlbox.cpp
@@ -1113,7 +1113,7 @@ void ControlBox::getServiceDetails(int index)
   QList<QString>::iterator i;
   for (i = sec_words.begin(); i != sec_words.end(); ++i)
       *i = cmtr(*i);
-  rs.append(tr("Security: %1<br>").arg(sec_words.join(', ')) );
+  rs.append(tr("Security: %1<br>").arg(sec_words.join(", ")) );
   if (! map.value("Strength").toString().isEmpty() ) rs.append(tr("Strength: %1<br>").arg(map.value("Strength").value<quint8>()) );
   rs.append(tr("Roaming: %1<br>").arg(map.value("Roaming").toBool() ? tr("Yes", "roaming") : tr("No", "roaming")) );
   
@@ -1459,7 +1459,7 @@ void ControlBox::assemblePage3()
       QList<QString>::iterator i;
       for (i = sec_words.begin(); i != sec_words.end(); ++i)
           *i = cmtr(*i);
-      qtwi03->setText(sec_words.join(', ') );
+      qtwi03->setText(sec_words.join(", ") );
       qtwi03->setTextAlignment(Qt::AlignCenter);
       ui.tableWidget_wifi->setItem(rowcount, 3, qtwi03);      
          
@@ -1532,7 +1532,7 @@ void ControlBox::assembleTrayIcon()
           QList<QString>::iterator qli;
           for (qli = sec_words.begin(); qli != sec_words.end(); ++qli)
               *qli = cmtr(*qli);
-          stt.append(tr("Security: %1<br>").arg(sec_words.join(', ')) );
+          stt.append(tr("Security: %1<br>").arg(sec_words.join(", ")) );
           stt.append(tr("Strength: %1%<br>").arg(services_list.at(0).objmap.value("Strength").value<quint8>()) );
           stt.append(tr("Interface: %1").arg(submap.value("Interface").toString()) );
           quint8 str = services_list.at(0).objmap.value("Strength").value<quint8>();


### PR DESCRIPTION
The current methodology for translating status strings and other strings from the Connman api is as follows: 
Pull property from dbus --> translate property in local variable --> run string comparisons in internal code to determine status -> display properties in GUI

I think this is a bad (and possibly dangerous) way to approach it. If we slip up anywhere we end up comparing a bunch of correct names coming from the Connman api to a bunch of mistranslated names internally, resulting in breakage. 

Case in point: the .ts for english translates "online" to "Online". Capitalizing it is correct for the GUI, but internally we were checking "Online" == "online" whenever we ran ```assembleTrayIcon()``` when reconnecting after a disconnect. This happened because ```properties_map.insert(name, value)``` in ```dbsPropertyChanged``` took the status (from the Connman api) and put it directly into the QMap without translating it first. 

We could try making sure that we always compare the right values and hope the translation files are all always right, or we could just use the correct api strings internally and then translate when we send to the GUI. I think the latter is better and much less error prone. This pull request implements this change, and fixes [#64](https://github.com/andrew-bibb/cmst/issues/64) as a side effect. It also fixes the symptoms of [#59](https://github.com/andrew-bibb/cmst/issues/59) for me, although I have only tested this in combination with my other pull request, [#63](https://github.com/andrew-bibb/cmst/pull/63). 

I think eventually we'll probably end up wanting all the API strings defined in a ```connman-api.h``` file, or perhaps in a namespace? I might take that to work on if you like the idea, but it might be a while before I have time to come back to it. 