### PR TITLE
Fix typo in 62bf4c80: TX packets shown in RX line

### DIFF
--- a/apps/cmstapp/code/counter/counter.cpp
+++ b/apps/cmstapp/code/counter/counter.cpp
@@ -96,10 +96,10 @@ QString ConnmanCounter::getLabel(const QVariantMap& map)
 
 	// Append to the label the total number of packets [errors and dropped] received.
 	rtn.append(tr("<br><br><b>Received:</b><br>RX Total: %1 (%2),  RX Errors: %3,  RX Dropped: %4") 						\
-																					.arg(tr("%Ln Packet(s)", 0, map.value("TX.Packets").toLongLong()) )	\  
+																					.arg(tr("%Ln Packet(s)", 0, map.value("RX.Packets").toLongLong()) )	\  
 																					.arg(datafield)																											\
-																					.arg(tr("%Ln Packet(s)", 0, map.value("TX.Errors").toLongLong()) )	\
-																					.arg(tr("%Ln Packet(s)", 0, map.value("TX.Dropped").toLongLong())) );			
+																					.arg(tr("%Ln Packet(s)", 0, map.value("RX.Errors").toLongLong()) )	\
+																					.arg(tr("%Ln Packet(s)", 0, map.value("RX.Dropped").toLongLong())) );			
 	
 	// Append the time title
 	rtn.append(tr("<br><br><b>Connect Time:</b><br>") );																																																																																							


### PR DESCRIPTION
Commit [62bf4c](https://github.com/andrew-bibb/cmst/commit/62bf4c800ea96b899dd40a31e2f638fedfd540f1) makes the packet counters for RX incorrectly show the values for TX. This branch fixes the regression. 
