### PR TITLE
Use a ComboBox instead of RadioButtons to display browser choices, and add a few browser choices

### DIFF
--- a/apps/cmstapp/code/agent/agent_dialog.cpp
+++ b/apps/cmstapp/code/agent/agent_dialog.cpp
@@ -127,7 +127,7 @@ int AgentDialog::showPage1(const QString& url)
 	if (! sys_env_path.isEmpty() ) {
 		QStringList sl_loop = sys_env_path.split(':');
 		QStringList sl_targets;
-		sl_targets << "firefox" << "opera" << "luakit" << "lynx";
+		sl_targets << "google-chrome" << "google-chrome-unstable" << "chromium" << "firefox" << "opera" << "luakit" << "lynx" << "xdg-open";
 		sl_browsers.clear();
 		for (int i = 0; i < sl_loop.size(); ++i) {
 			QDir dir = QDir(sl_loop.at(i));

--- a/apps/cmstapp/code/agent/agent_dialog.h
+++ b/apps/cmstapp/code/agent/agent_dialog.h
@@ -63,7 +63,6 @@ class AgentDialog : public QDialog
 		void hidePassphrase(bool);
 		void useWPSPushButton(bool);		
 		void showWhatsThis();
-		void useOtherBrowser(bool);
 		void launchBrowser();
 		
 	public:

--- a/apps/cmstapp/code/agent/agent_dialog.h
+++ b/apps/cmstapp/code/agent/agent_dialog.h
@@ -64,6 +64,8 @@ class AgentDialog : public QDialog
 		void useWPSPushButton(bool);		
 		void showWhatsThis();
 		void launchBrowser();
+		void updateBrowserChoice(const QModelIndex&, const QModelIndex&);
+		void enteringBrowser(const QString&);
 		
 	public:
 		inline void setWhatsThisIcon(QIcon icon) {ui.toolButton_whatsthis->setIcon(icon);}

--- a/apps/cmstapp/code/agent/ui/agent.ui
+++ b/apps/cmstapp/code/agent/ui/agent.ui
@@ -287,11 +287,7 @@
          </property>
          <layout class="QGridLayout" name="gridLayout_7">
           <item row="3" column="0">
-           <widget class="QComboBox" name="comboBox_browser">
-            <property name="editable">
-             <bool>true</bool>
-            </property>
-           </widget>
+           <widget class="QLineEdit" name="lineEdit_browser"/>
           </item>
           <item row="2" column="0">
            <widget class="QLabel" name="label_browser">
@@ -334,7 +330,7 @@
             </item>
            </layout>
           </item>
-          <item row="6" column="0">
+          <item row="7" column="0">
            <widget class="QPushButton" name="pushButton_launch_browser">
             <property name="whatsThis">
              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use this button to launch the selected browser. The browser will open at the page shown in the Login URL box.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -344,7 +340,7 @@
             </property>
            </widget>
           </item>
-          <item row="7" column="0">
+          <item row="8" column="0">
            <spacer name="verticalSpacer">
             <property name="orientation">
              <enum>Qt::Vertical</enum>
@@ -356,6 +352,9 @@
              </size>
             </property>
            </spacer>
+          </item>
+          <item row="4" column="0">
+           <widget class="QListView" name="listView_browsers"/>
           </item>
          </layout>
         </widget>

--- a/apps/cmstapp/code/agent/ui/agent.ui
+++ b/apps/cmstapp/code/agent/ui/agent.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>386</width>
-    <height>587</height>
+    <height>642</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -17,7 +17,7 @@
    <item row="0" column="0">
     <widget class="QStackedWidget" name="stackedWidget">
      <property name="currentIndex">
-      <number>0</number>
+      <number>1</number>
      </property>
      <widget class="QWidget" name="page_01">
       <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -70,7 +70,7 @@
           <item row="1" column="0">
            <widget class="QLabel" name="label_old_passphrase">
             <property name="text">
-             <string>&amp;Old Passphrase</string>
+             <string>O&amp;ld Passphrase</string>
             </property>
             <property name="buddy">
              <cstring>lineEdit_old_passphrase</cstring>
@@ -286,6 +286,20 @@
           <string>Browser Login Requested</string>
          </property>
          <layout class="QGridLayout" name="gridLayout_7">
+          <item row="3" column="0">
+           <widget class="QComboBox" name="comboBox_browser">
+            <property name="editable">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_browser">
+            <property name="text">
+             <string>Choose or enter a browser:</string>
+            </property>
+           </widget>
+          </item>
           <item row="0" column="0">
            <widget class="QLabel" name="label_browser_url">
             <property name="text">
@@ -320,71 +334,7 @@
             </item>
            </layout>
           </item>
-          <item row="2" column="0">
-           <layout class="QGridLayout" name="gridLayout_3">
-            <item row="0" column="0">
-             <widget class="QRadioButton" name="radioButton_firefox">
-              <property name="toolTip">
-               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-              </property>
-              <property name="whatsThis">
-               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use  the Firefox browser.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-              </property>
-              <property name="text">
-               <string>&amp;Firefox</string>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="1">
-             <widget class="QRadioButton" name="radioButton_opera">
-              <property name="whatsThis">
-               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use the Opera browser.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-              </property>
-              <property name="text">
-               <string>&amp;Opera</string>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="0">
-             <widget class="QRadioButton" name="radioButton_luakit">
-              <property name="whatsThis">
-               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use the Luakit browser.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-              </property>
-              <property name="text">
-               <string>&amp;Luakit</string>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="1">
-             <widget class="QRadioButton" name="radioButton_lynx">
-              <property name="whatsThis">
-               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use the Lynx (console mode) browser.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-              </property>
-              <property name="text">
-               <string>Lyn&amp;x</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-          <item row="3" column="0">
-           <widget class="QRadioButton" name="radioButton_other">
-            <property name="whatsThis">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Login using a browser that is not listed.  Type the browser start command in the box below.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-            <property name="text">
-             <string>Othe&amp;r</string>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="0">
-           <widget class="QLineEdit" name="lineEdit_other_browser">
-            <property name="whatsThis">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Type the browser start command here.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="0">
+          <item row="6" column="0">
            <widget class="QPushButton" name="pushButton_launch_browser">
             <property name="whatsThis">
              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use this button to launch the selected browser. The browser will open at the page shown in the Login URL box.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -394,7 +344,7 @@
             </property>
            </widget>
           </item>
-          <item row="6" column="0">
+          <item row="7" column="0">
            <spacer name="verticalSpacer">
             <property name="orientation">
              <enum>Qt::Vertical</enum>


### PR DESCRIPTION
This is to fix #86.

The radio buttons are replaced with a combobox in order to make it easier to add browser choices. A disadvantage of this is that the user needs to click on the combobox to show its dropdown list, and then select a choice, so it involves 2 clicks instead of 1 as before. However, it does make the code much simpler.