### PR TITLE
Minimize to tray when escape is pressed

### DIFF
--- a/apps/cmstapp/code/control_box/controlbox.cpp
+++ b/apps/cmstapp/code/control_box/controlbox.cpp
@@ -38,6 +38,7 @@ DEALINGS IN THE SOFTWARE.
 # include <QPixmap>
 # include <QMessageBox>
 # include <QCloseEvent>
+# include <QKeyEvent>
 # include <QToolTip>
 # include <QTableWidgetSelectionRange>
 # include <QProcessEnvironment>
@@ -1206,6 +1207,19 @@ void ControlBox::closeEvent(QCloseEvent* e)
 	else
 		e->accept();
   return;
+}
+//
+// Key event for this dialog. If escape is pressed, minimize instead of close if
+// applicable.
+void ControlBox::keyPressEvent(QKeyEvent* e)
+{
+	if (e->key() == Qt::Key_Escape &&
+	    trayicon != 0 &&
+	    trayicon->isVisible()) {
+		this->hide();
+		return;
+	}
+        QDialog::keyPressEvent(e);
 }
 //
 // Event filter used to filter out tooltip events if we don't want to see them

--- a/apps/cmstapp/code/control_box/controlbox.h
+++ b/apps/cmstapp/code/control_box/controlbox.h
@@ -117,6 +117,7 @@ class ControlBox : public QDialog
     
   protected:
     void closeEvent(QCloseEvent*);
+    void keyPressEvent(QKeyEvent*);
     bool eventFilter(QObject*, QEvent*);   
     
   private:


### PR DESCRIPTION
I think the current close-to-tray behavior of the control box is inconsistent: closing via the window manager (titlebar or keyboard) hides to the tray, but closing via the escape key quits. This patch handles escape key events in the same way as close events.