### PR TITLE
Fix typo: noticable -> noticeable

### DIFF
--- a/misc/manpage/cmst.1
+++ b/misc/manpage/cmst.1
@@ -120,7 +120,7 @@ For the tray icon to display is it required that the system tray be compliant wi
 
 The tray icon is known to not work in the DWM system tray which appears to be a noncompliant tray.
 
-Tray icons will display with a black background, this is particularly noticable when you have a light colored tray.  This is a QT5 bug. 
+Tray icons will display with a black background, this is particularly noticeable when you have a light colored tray.  This is a QT5 bug. 
 .SH Author
 Andrew J. Bibb.  Project web page: https://github.com/andrew-bibb/cmst
 


### PR DESCRIPTION
The following typo is found when we try to create Debian package for cmst. This patch fix the typo

```
I: cmst: spelling-error-in-manpage usr/share/man/man1/cmst.1.gz noticable noticeable
N: 
N:    Lintian found a spelling error in the manpage. Lintian has a list of
N:    common misspellings that it looks for. It does not have a dictionary
N:    like a spelling checker does.
N:    
N:    If the string containing the spelling error is translated with the help
N:    of gettext (with the help of po4a, for example) or a similar tool,
N:    please fix the error in the translations as well as the English text to
N:    avoid making the translations fuzzy. With gettext, for example, this
N:    means you should also fix the spelling mistake in the corresponding
N:    msgids in the *.po files.
N:    
N:    Severity: minor, Certainty: possible
N:    
N:    Check: manpages, Type: binary
```