### PR TITLE
Improve compliance with the Desktop Entry Specification

### DIFF
--- a/misc/desktop/cmst-autostart.desktop
+++ b/misc/desktop/cmst-autostart.desktop
@@ -1,10 +1,10 @@
 [Desktop Entry]
 Type=Application
-Version=1.1
+Version=1.0
 Name=Connman UI Setup
 GenericName=Network Configuration
 Comment=QT GUI frontend for connman
-Categories=Settings;System;Qt;Network
+Categories=Settings;System;Qt;Network;
 Icon=cmst
 Exec=cmst
 Terminal=false

--- a/misc/desktop/cmst.desktop
+++ b/misc/desktop/cmst.desktop
@@ -1,10 +1,10 @@
 [Desktop Entry]
 Type=Application
-Version=1.1
+Version=1.0
 Name=Connman UI Setup
 GenericName=Network Configuration
 Comment=QT GUI frontend for connman
-Categories=Settings;System;Qt;Network
+Categories=Settings;System;Qt;Network;
 Icon=cmst
 Terminal=false
 Exec=cmst


### PR DESCRIPTION
Even though the latest version of the specification is 1.1, it states:
"Entries that confirm with this version of the specification should use 1.0".

Also, "Categories" should end with a semicolon.