### PR TITLE
Add keywords to the .desktops files

### DIFF
--- a/misc/desktop/cmst-autostart.desktop
+++ b/misc/desktop/cmst-autostart.desktop
@@ -10,6 +10,7 @@ Exec=cmst -w5
 Terminal=false
 StartupNotify=false
 X-GNOME-Autostart-enabled=true
+Keywords=Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Bluetooth;vpn;DNS;
 
 Name[de]=Netzwerk-Konfiguration
 

--- a/misc/desktop/cmst.desktop
+++ b/misc/desktop/cmst.desktop
@@ -10,6 +10,7 @@ Terminal=false
 Exec=cmst
 StartupNotify=false
 X-GNOME-Autostart-enabled=true
+Keywords=Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Bluetooth;vpn;DNS;
 
 Name[de]=Netzwerk-Konfiguration
 


### PR DESCRIPTION
Hello

i'm currently backporting CMST for Debian Jessie.

and lintian complying about missing keywords in the desktops files.
https://mentors.debian.net/package/cmst
https://lintian.debian.org/tags/desktop-entry-lacks-keywords-entry.html

I just took the keywords from gnome-control-panel gnome-network-panel.desktop file and removed the Modem keyword.

Kristian