### PR TITLE
Add missing send_destination to roothelper dbus policy file

### DIFF
--- a/apps/rootapp/system/distro/arch/org.cmst.roothelper.conf
+++ b/apps/rootapp/system/distro/arch/org.cmst.roothelper.conf
@@ -6,11 +6,11 @@
     <!-- Only root can own roothelper -->
     <policy user="root">
         <allow own="org.cmst.roothelper"/>
-        <allow send_destination="org.cmst.roothelper"/>
-        <allow send_interface="org.cmst.roothelper"/>
+        <allow send_destination="org.cmst.roothelper"
+               send_interface="org.cmst.roothelper"/>
     </policy>
     <policy group="network">
-        <allow send_destination="org.cmst.roothelper"/>
-        <allow send_interface="org.cmst.roothelper"/>
+        <allow send_destination="org.cmst.roothelper"
+               send_interface="org.cmst.roothelper"/>
     </policy>
 </busconfig>

--- a/apps/rootapp/system/distro/debian/org.cmst.roothelper.conf
+++ b/apps/rootapp/system/distro/debian/org.cmst.roothelper.conf
@@ -6,11 +6,11 @@
     <!-- Only root can own roothelper -->
     <policy user="root">
         <allow own="org.cmst.roothelper"/>
-        <allow send_destination="org.cmst.roothelper"/>
-        <allow send_interface="org.cmst.roothelper"/>
+        <allow send_destination="org.cmst.roothelper"
+               send_interface="org.cmst.roothelper"/>
     </policy>
-    <policy group="netdev">
-        <allow send_destination="org.cmst.roothelper"/>
-        <allow send_interface="org.cmst.roothelper"/>
+    <policy group="network">
+        <allow send_destination="org.cmst.roothelper"
+               send_interface="org.cmst.roothelper"/>
     </policy>
 </busconfig>

--- a/apps/rootapp/system/distro/slackware/org.cmst.roothelper.conf
+++ b/apps/rootapp/system/distro/slackware/org.cmst.roothelper.conf
@@ -6,11 +6,11 @@
     <!-- Only root can own roothelper -->
     <policy user="root">
         <allow own="org.cmst.roothelper"/>
-        <allow send_destination="org.cmst.roothelper"/>
-        <allow send_interface="org.cmst.roothelper"/>
+        <allow send_destination="org.cmst.roothelper"
+               send_interface="org.cmst.roothelper"/>
     </policy>
-    <policy group="netdev">
-        <allow send_destination="org.cmst.roothelper"/>
-        <allow send_interface="org.cmst.roothelper"/>
+    <policy group="network">
+        <allow send_destination="org.cmst.roothelper"
+               send_interface="org.cmst.roothelper"/>
     </policy>
 </busconfig>


### PR DESCRIPTION
This is a security issue, as explained here:
https://lists.freedesktop.org/archives/dbus/2008-February/009401.html

----
Lintain complained about this..
https://mentors.debian.net/package/cmst
https://lintian.debian.org/tags/dbus-policy-without-send-destination.html

I haven't tested it and I don't know if this result in some side effects.. @andrew-bibb can you test it?