### PR TITLE
Surpress 'Critical Error' message for connman-vpn

### DIFF
--- a/apps/cmstapp/code/control_box/controlbox.cpp
+++ b/apps/cmstapp/code/control_box/controlbox.cpp
@@ -2765,8 +2765,6 @@ void ControlBox::logErrors(const quint8& err)
       break;
     case  CMST::Err_Invalid_VPN_Iface:
       syslog(LOG_ERR, "%s",tr("Could not create an interface to connman-vpn on the system bus").toUtf8().constData());
-      QMessageBox::critical(this, tr("%1 - Critical Error").arg(TranslateStrings::cmtr("cmst")),
-        tr("Unable to create an interface to connman-vpn on the system bus.<br><br>%1 will not be able to communicate with the connman vpn daemon.").arg(TranslateStrings::cmtr("cmst")) );
       break;
     default:
       break;


### PR DESCRIPTION
it should be enough to log this in the syslog.
Thanks @klausenbusk