### PR TITLE
build: fix icons install check

### DIFF
--- a/cmst.pro
+++ b/cmst.pro
@@ -26,7 +26,7 @@ documentation.extra = gzip --force --keep ./misc/manpage/cmst.1
 INSTALLS += documentation
 
 # application icons - 
-exists(./images/application/cmst-icon.png) 
+exists(./images/application/cmst-icon.png) {
 	LIST = 16 20 22 24 32 36 40 48 64 72 96 128 192 256 384 512
 	for(a, LIST) {
 		icon$${a}.path = /usr/share/icons/hicolor/$${a}x$${a}/apps
@@ -38,7 +38,7 @@ exists(./images/application/cmst-icon.png)
 		iconsvg.files = ./images/application/scalable/cmst.svg
 		INSTALLS += iconsvg
 	}
-else {
+} else {
 	system(sed -i 's/Icon=cmst/Icon=preferences-system-network/g' "./misc/desktop/cmst.desktop")
 	system(sed -i 's/Icon=cmst/Icon=preferences-system-network/g' "./misc/desktop/cmst-autostart.desktop")
 }


### PR DESCRIPTION
Otherwise exists(./images/application/cmst-icon.png) check is ignored.