### PR TITLE
controlBox: Correct dialog size on HiDPI monitors

### DIFF
--- a/apps/cmstapp/code/control_box/controlbox.cpp
+++ b/apps/cmstapp/code/control_box/controlbox.cpp
@@ -205,15 +205,14 @@ ControlBox::ControlBox(const QCommandLineParser& parser, QWidget *parent)
     settings->endGroup();
   }
 
-  // Make sure the controlbox will fit onto small acreens
+  // Make sure the controlbox will fit onto small screens (& resize to sizeHint() for HiDPI screens)
   QSize sz_target = (qApp->desktop()->availableGeometry(this)).size();
   QSize sz_source = this->sizeHint();
-  sz_target.scale(sz_target.width() - 100, sz_target.height() - 100, Qt::KeepAspectRatio); // give me a little buffer
   if (sz_source.width() > sz_target.width() || sz_source.height() > sz_target.height() ) {
-    sz_source.scale(sz_target.width(), sz_target.height(), Qt::KeepAspectRatio);
-    resize(sz_source);
-    move(25, 25);
+    sz_source.scale(sz_target.width() - 100, sz_target.height() - 100, Qt::KeepAspectRatio); // keep min. 100 pixels around dialog
   }
+  resize(sz_source);
+  move((sz_target.width() - this->width()) / 2, (sz_target.height() - this->height()) / 2); // re-centre if needed
 
   // set a flag if we sent a commandline option to log the connman inputrequest
   agent->setLogInputRequest(parser.isSet("log-input-request"));


### PR DESCRIPTION
Hi,

Thanks for cmst, I've been using it for a while now and it's super useful.

Since getting a HiDPI display I've noticed that although Qt5 correctly scales widgets, layout, etc, the default dialog size stays the same. This requires a manual resize the first time cmst is opened, in order to see all the controls.

It seems sizeHint() correctly accounts for different DPI values so this PR changes the main dialog to always resize to sizeHint() in the constructor. I don't think this will make any difference to the dialog size on standard DPI displays, although I haven't tested on one.

Cheers,

Angus