### PR TITLE
Only call connectNotityClient when needed

### DIFF
--- a/apps/cmstapp/code/control_box/controlbox.cpp
+++ b/apps/cmstapp/code/control_box/controlbox.cpp
@@ -307,13 +307,17 @@ ControlBox::ControlBox(const QCommandLineParser& parser, QWidget *parent)
   ui.groupBox_process->setVisible(ui.checkBox_advanced->isChecked() );
   enableRunOnStartup(ui.checkBox_runonstartup->isChecked() );
 
-  // Create the notifyclient, make four tries; first immediately in constructor, then
-  // at 1/2 second, 2 seconds and finally at 8 seconds
+  // Create the notifyclient.
   notifyclient = new NotifyClient(this);
-  this->connectNotifyClient();
-  QTimer::singleShot(500, this, SLOT(connectNotifyClient()));
-  QTimer::singleShot(2 * 1000, this, SLOT(connectNotifyClient()));
-  QTimer::singleShot(8 * 1000, this, SLOT(connectNotifyClient()));
+  // Only try to connect to the notifyclient if we actually need it
+  if(this->settings->value("enable_daemon_notifications").toBool()) {
+    // Make four tries; first immediately, then
+    // at 1/2 second, 2 seconds and finally at 8 seconds
+    this->connectNotifyClient();
+    QTimer::singleShot(500, this, SLOT(connectNotifyClient()));
+    QTimer::singleShot(2 * 1000, this, SLOT(connectNotifyClient()));
+    QTimer::singleShot(8 * 1000, this, SLOT(connectNotifyClient()));
+  }
 
   // setup the dbus interface to connman.manager
   con_manager = NULL;

--- a/apps/cmstapp/code/notify/notify.cpp
+++ b/apps/cmstapp/code/notify/notify.cpp
@@ -59,9 +59,6 @@ NotifyClient::NotifyClient(QObject* parent)
   // Create our client and try to connect to the notify server
   if (! QDBusConnection::sessionBus().isConnected() )
     qCritical("CMST - Cannot connect to the session bus.");
-  // else try to connect to a notification server
-  else 
-		connectToServer();
 		
 	// Signals and slots
 	connect(qApp, SIGNAL(aboutToQuit()), this, SLOT(cleanUp()));	
@@ -77,7 +74,7 @@ void NotifyClient::connectToServer()
 {
 	// return now if we already have a valid connection
   if (b_validconnection) return;
-    
+
   notifyclient = new QDBusInterface(DBUS_NOTIFY_SERVICE, DBUS_NOTIFY_PATH, DBUS_NOTIFY_INTERFACE, QDBusConnection::sessionBus(), this); 
   if (notifyclient->isValid() ) {
     b_validconnection = true;


### PR DESCRIPTION
Only call connectNotitfy when the setting
"enable_daemon_notifications" is true, to avoid
unnecessary DBUS timeout wait time on CMST launch