### PR TITLE
fix connmand version detection

### DIFF
--- a/apps/cmstapp/code/control_box/controlbox.cpp
+++ b/apps/cmstapp/code/control_box/controlbox.cpp
@@ -3032,7 +3032,7 @@ void ControlBox::findConnmanVersion()
   QProcess qps;
   bool b_ok = false;
 
-  qps.start("connmand -v", QStringList());
+  qps.start("connmand", {"-v"});
   qps.waitForFinished();
   f_connmanversion = qps.readAllStandardOutput().toFloat(&b_ok);
   if (! b_ok) f_connmanversion = -1.0; 


### PR DESCRIPTION
I'm running connmand 1.38 on Void Linux and I noticed that cmst doesn't have wireguard VPN edit options. Looking at the code I found out that wireguard options are only visible when `f_connmanversion` is higher that `1.37`. So I added some printfs to the code, rebuilt the program and it turned out that `f_connmanversion` is `-1`.

This seems incorrect and results in `f_connmanversion = -1.0`:
```
qps.start("connmand -v", QStringList());
```

This works:
```
qps.start("connmand", {"-v"});
```