### PR TITLE
fix(build): use shorthand gzip flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,13 @@ The [Wiki](https://github.com/andrew-bibb/cmst/wiki) has been started and announ
 
 On Arch Linux CMST has been dropped from the community repository and may be found in the AUR.
 
-The Provisioning Editor and VPN Provisioning Editor both register a root helper to assist in editing files in directories owned by root (/var/lib/connman and /var/lib/connman-vpn).  In order to use the root helper you must be a member of the proper group, and this group varies by distribution.  To get the proper file for your distribution you need to provide it on the qmake line. Currently there are files for Arch Linux, Slackware, and Debian.  If you are on Arch you don't actually need to supply the distro as that is the default if one is not supplied, but it is not wrong to do so. 
+The Provisioning Editor and VPN Provisioning Editor both register a root helper to assist in editing files in directories owned by root (/var/lib/connman and /var/lib/connman-vpn).  In order to use the root helper you must be a member of the proper group, and this group varies by distribution.  To get the proper file for your distribution you need to provide it on the qmake line. Currently there are files for Arch Linux, Slackware, and Debian. Alpine works with Arch config files. If you are on Arch you don't actually need to supply the distro as that is the default if one is not supplied, but it is not wrong to do so.
+
+## Dependencies
+
+`qtchooser` and `qt5-qttools-dev` are required to build.
+
+## Building
 
 If you are not on Arch download the release and extract the files.  Then run:
 

--- a/cmst.pro
+++ b/cmst.pro
@@ -11,7 +11,7 @@ include(cmst.pri)
 documentation.path = $$CMST_DOC_PATH/man1
 documentation.files = ./misc/manpage/cmst.1.gz
 documentation.CONFIG = no_check_exist
-documentation.extra = gzip --force --keep ./misc/manpage/cmst.1
+documentation.extra = gzip -kf ./misc/manpage/cmst.1
 INSTALLS += documentation
 
 # application icons -


### PR DESCRIPTION
`--force` and `--keep` only seem to work when called directly on busybox distros and therefore `-fk` needs to be used. Also, add info about build deps and that Alpine works with Arch config.