### PR TITLE
Fix tray icon on HiDPI displays

### DIFF
--- a/apps/cmstapp/code/control_box/controlbox.cpp
+++ b/apps/cmstapp/code/control_box/controlbox.cpp
@@ -2529,6 +2529,7 @@ void ControlBox::assembleTrayIcon()
    QPixmap pxm = prelimicon.pixmap(prelimicon.actualSize((QSize(22,22) *= iconscale)) );
    QImage src = pxm.toImage();
    QImage dest = QImage(src.width(), src.height(), QImage::Format_ARGB32);
+   dest.setDevicePixelRatio(src.devicePixelRatio());
    QPainter painter(&dest);
    if (trayiconbackground.isValid() && src.hasAlphaChannel() ) {
       painter.setCompositionMode(QPainter::CompositionMode_Source);


### PR DESCRIPTION
Qt icons use scaling factor.
When new icon is created, default scaling factor 1 is set. If display has scaling factor 2, source image also has scaling factor 2. In that case when source image is rendered on destination image with scaling factor 1, resulting icon only uses 1/2 of width of icon and 1/2 of height of icon.
Also copy scaling factor from source image to fix this issue.