### PR TITLE
Qt6 Transition

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ assist in obtaining the information from you necessary to logon the wifi service
 
 As of 2016.01.26 support for VPN connections (create, edit, delete, connect and disconnect) has been added.  It is also possible to import an OpenVPN .opvn file.  The import function will scan the .opvn file extracting and saving keys and certificates, and then place the proper lines into the provisioning editor.
 
-The program requires that connman be installed and running.  The program depends on QT5, but only the base package. 
+The program requires that connman be installed and running.  The program depends on QT6, but only the base package. 
 
 The [Wiki](https://github.com/andrew-bibb/cmst/wiki) has been started and announcements, news, and other information can be found there.
 
@@ -24,13 +24,13 @@ The Provisioning Editor and VPN Provisioning Editor both register a root helper 
 
 ## Dependencies
 
-`qtchooser` and `qt5-qttools-dev` are required to build.
+`qmake6` and `qt6-qttools-dev` are required to build.
 
 ## Building
 
 If you are not on Arch download the release and extract the files.  Then run:
 
-    qmake DISTRO=xxxx
+    qmake6 DISTRO=xxxx
     make
     make install (as root)
 

--- a/apps/cmstapp/code/iconman/iconman.cpp
+++ b/apps/cmstapp/code/iconman/iconman.cpp
@@ -258,7 +258,7 @@ bool IconManager::buildResourceIcon(QIcon& icon, const QString& name, const QStr
    // see if we need to colorize
    QColor qc_col = QColor();
    if (s_col.contains("yes", Qt::CaseInsensitive) || s_col == "1" ) qc_col = icon_color;
-   else if (s_col.size() == 6) qc_col.setNamedColor(QString("#" + s_col) );
+   else if (s_col.size() == 6) qc_col.fromString(QString("#" + s_col) );
 
    // check to see if the names exist, if they do build the icon
    if (QFileInfo(name_on.section(' ', 0, 0)).exists() ) {


### PR DESCRIPTION
This makes the transition to Qt6 official. This will allow distros to continue packaging as they make the move from Qt5 to Qt6, as is presently ongoing in distros such as Fedora, Debian Testing/Trixie and Ubuntu